### PR TITLE
Fix README typo in streamlit section

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ pipenv shell
 pip install -r requirements.txt
 ```
 
-## Run steamlit app
+## Run streamlit app
 ```
 streamlit run dashboard.py
 ```


### PR DESCRIPTION
## Summary
- fix typo in README run streamlit section

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6895911c17d88321bd27dc4b555479ca